### PR TITLE
asset: Add mock sprite data for wireframing and styling

### DIFF
--- a/src/assets/mock-sprites.js
+++ b/src/assets/mock-sprites.js
@@ -1,0 +1,55 @@
+export const frontSprites = [
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/3.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/5.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/6.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/8.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/9.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/10.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/11.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/12.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/13.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/14.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/15.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/16.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/17.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/18.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/19.png',
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/20.png',
+];
+
+export const bulbasaur = {
+back_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/1.png',
+back_female: null,
+back_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/1.png',
+back_shiny_female: null,
+front_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png',
+front_female: null,
+front_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/1.png',
+front_shiny_female: null
+}
+
+export const charmander = {
+back_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/4.png',
+back_female: null,
+back_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/4.png',
+back_shiny_female: null,
+front_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png',
+front_female: null,
+front_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/4.png',
+front_shiny_female: null
+}
+
+export const squirtle = {
+back_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/7.png',
+back_female: null,
+back_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/7.png',
+back_shiny_female: null,
+front_default: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png',
+front_female: null,
+front_shiny: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/7.png',
+front_shiny_female: null
+}


### PR DESCRIPTION
### Description
This adds sprite assets for wireframing and styling. Will be replaced with the data fetched from the API in later iterations.

### Related Issue(s)
- closes #3 

### Changes

- Created `assets` directory in `src`
- Touched `mock-sprites.js` in `assets`
- In `mock-sprites.js`, created an array of 20 different URLs for 20 different Pokemon sprites
- In `mock-sprites.js`, created three different objects for the three Gen 1 starter Pokemon containing all their sprites

### Additional Notes

- I copy/pasted the API data for the three starters. I decided to include the null properties so it more closely matched the API.
