### PR TITLE
style: Add spriteview wireframe

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -2,12 +2,14 @@ import React from 'react';
 import './App.css';
 import Header from '../Header/Header';
 import HomeView from '../HomeView/HomeView';
+import SpriteView from '../SpriteView/SpriteView';
 
 const App = () => {
   return (
     <>
       <Header />
-      <HomeView />
+      {/* <HomeView /> */}
+      <SpriteView />
     </>
   );
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -7,8 +7,7 @@ header {
 
 .logo-container {
   display: flex;
-  width: 50%;
-  width: calc(50% + 60px);
+  width: calc(50% + 30px);
   justify-content: space-between;
   align-items: center;
 }

--- a/src/components/Sprite/Sprite.css
+++ b/src/components/Sprite/Sprite.css
@@ -1,0 +1,3 @@
+.sprite {
+  margin: 1%;
+}

--- a/src/components/Sprite/Sprite.js
+++ b/src/components/Sprite/Sprite.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import './Sprite.css';
 
-const Sprite = () => {
+const Sprite = ({ sprite }) => {
   return (
-    <div>
-      
+    <div className='sprite'>
+      <img src={sprite} />
     </div>
   );
 }

--- a/src/components/SpriteView/SpriteView.css
+++ b/src/components/SpriteView/SpriteView.css
@@ -1,0 +1,4 @@
+h2 {
+  margin: 0;
+  margin-top: 100px;
+}

--- a/src/components/SpriteView/SpriteView.js
+++ b/src/components/SpriteView/SpriteView.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import './SpriteView.css';
+import SpritesContainer from '../SpritesContainer/SpritesContainer';
 
 const SpriteView = () => {
   return (
-    <div>
-      
-    </div>
+    <main>
+      <h2>Pokemon</h2>
+      <SpritesContainer />
+    </main>
   );
 }
 

--- a/src/components/SpritesContainer/SpritesContainer.css
+++ b/src/components/SpritesContainer/SpritesContainer.css
@@ -1,0 +1,7 @@
+.sprites-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/src/components/SpritesContainer/SpritesContainer.js
+++ b/src/components/SpritesContainer/SpritesContainer.js
@@ -1,11 +1,24 @@
 import React from 'react';
 import './SpritesContainer.css';
+import Sprite from '../Sprite/Sprite';
+
+// Temp placeholders for styling
+import { bulbasaur } from '../../assets/mock-sprites';
+import { charmander } from '../../assets/mock-sprites';
 
 const SpritesContainer = () => {
+  const spriteKeys = Object.keys(bulbasaur);
+  const sprites = spriteKeys.map(key => {
+    if (bulbasaur[key]) {
+      console.log(bulbasaur)
+      return <Sprite sprite={bulbasaur[key]} />
+    }
+  });
+
   return (
-    <div>
-      
-    </div>
+    <section className='sprites-container'>
+      {sprites}
+    </section>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 * {
-
+  border: 1px solid red;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
### Description
This adds the wireframe for the sprite view

### Related Issue(s)
- closes #6 

### Changes

- Adds wireframe for all components related to the sprite view
- Adjusts the header pokeball logo to be more centered (adjusted the `calc` in `Header.css`)

### Additional Notes

- Updated the last two checkboxes in #6 because checking the Router and conditional rendering was beyond the scope of this iteration. Also, the mock data does not match the API data perfectly, as it was intended to be a simply fix to allow styling. It would be overly complicated and not advantageous to solve the Router issue due the limited timeframe of this project.
