### PR TITLE
Feature/get pokemon

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { Route, Routes } from 'react-router-dom';
 import './App.css';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
 import Header from '../Header/Header';
 import HomeView from '../HomeView/HomeView';
 import SpriteView from '../SpriteView/SpriteView';
-import { Route, Routes } from 'react-router-dom';
+import fetchPokemon from '../../utils/apiCalls';
 
 const App = () => {
+  useEffect(() => {
+    fetchPokemon()
+      .then(data => console.log(data))
+  }, [])
+
   return (
     <>
       <Header/>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import './App.css';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
@@ -7,6 +7,8 @@ import HomeView from '../HomeView/HomeView';
 import SpriteView from '../SpriteView/SpriteView';
 
 const App = () => {
+  // const [pokemonUrl, setPokemonUrl] = useState('')
+
   return (
     <>
       <Header/>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import './App.css';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
@@ -7,8 +7,6 @@ import HomeView from '../HomeView/HomeView';
 import SpriteView from '../SpriteView/SpriteView';
 
 const App = () => {
-  // const [pokemonUrl, setPokemonUrl] = useState('')
-
   return (
     <>
       <Header/>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,14 +5,8 @@ import ErrorMessage from '../ErrorMessage/ErrorMessage';
 import Header from '../Header/Header';
 import HomeView from '../HomeView/HomeView';
 import SpriteView from '../SpriteView/SpriteView';
-import fetchPokemon from '../../utils/apiCalls';
 
 const App = () => {
-  useEffect(() => {
-    fetchPokemon()
-      .then(data => console.log(data))
-  }, [])
-
   return (
     <>
       <Header/>

--- a/src/components/Pokemon/Pokemon.js
+++ b/src/components/Pokemon/Pokemon.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './Pokemon.css';
 
-const Pokemon = ({ frontSprite }) => {
+const Pokemon = ({ dexNum, name }) => {
+  const spriteSrc = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${dexNum}.png`
+
   return (
     <figure>
       <Link to='/bulbasaur' className='pokemon-link'>
-        <img src={frontSprite} />
+        <img src={spriteSrc} />
         <figcaption>
-          <p>#0001 | Pokemon</p>
+          <p>{`${dexNum} | ${name}`}</p>
         </figcaption>
       </Link>
     </figure>

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -19,7 +19,7 @@ const PokemonContainer = () => {
     .then(newPokemon => {
       const selectedPokemonComponents = newPokemon.map((pokemon, i) => {
         return (
-          <Pokemon dexNum={i + 1} name={pokemon.name} />
+          <Pokemon key={i} dexNum={i + 1} name={pokemon.name} />
         )
       });
 

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -1,16 +1,37 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './PokemonContainer.css';
+import fetchPokemon from '../../utils/apiCalls';
 import Pokemon from '../Pokemon/Pokemon';
 
 // Temp placeholders for styling
 import { frontSprites } from '../../assets/mock-sprites';
 
 const PokemonContainer = () => {
-  const pokemonIcons = frontSprites.map(icon => <Pokemon frontSprite={icon} />);
+  const [pokeList, setPokeList] = useState([]);
+  const [pokemonComponents, setPokemonComponents] = useState([])
+  const [nextUrl, setNextUrl] = useState('');
+
+  useEffect(() => {
+    fetchPokemon()
+    .then(data => {
+      setPokeList([...data.results]);
+      setNextUrl(data.next);
+      return data.results;
+    })
+    .then(newPokemon => {
+      const newPokemonComponents = newPokemon.map((pokemon, i) => {
+        return (
+          <Pokemon dexNum={i + 1} name={pokemon.name} />
+        )
+      });
+
+      setPokemonComponents(newPokemonComponents)
+    });
+  }, []);
 
   return (
     <section className='pokemon-container'>
-      {pokemonIcons}
+      {pokemonComponents}
     </section>
   );
 }

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -8,28 +8,28 @@ import { frontSprites } from '../../assets/mock-sprites';
 
 const PokemonContainer = () => {
   const [pokeList, setPokeList] = useState([]);
-  const [pokemonComponents, setPokemonComponents] = useState([])
+  const [pokemon, setPokemon] = useState([])
 
   useEffect(() => {
     fetchPokemon()
     .then(data => {
       setPokeList([...data.results]);
-      return data.results;
     })
-    .then(newPokemon => {
-      const selectedPokemonComponents = newPokemon.map((pokemon, i) => {
-        return (
-          <Pokemon key={i} dexNum={i + 1} name={pokemon.name} />
-        )
-      });
-
-      setPokemonComponents(selectedPokemonComponents)
-    });
   }, []);
+
+  useEffect(() => {
+    const pokemon = pokeList.length > 0 && pokeList.map((pokemon, i) => {
+      return (
+        <Pokemon key={i} dexNum={i + 1} name={pokemon.name} />
+      )
+    });
+
+    setPokemon(pokemon);
+  }, [pokeList]);
 
   return (
     <section className='pokemon-container'>
-      {pokemonComponents}
+      {pokemon}
     </section>
   );
 }

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import './PokemonContainer.css';
 import fetchPokemon from '../../utils/apiCalls';
+import ErrorMessage from '../ErrorMessage/ErrorMessage';
 import Pokemon from '../Pokemon/Pokemon';
 
 // Temp placeholders for styling
@@ -9,11 +10,16 @@ import { frontSprites } from '../../assets/mock-sprites';
 const PokemonContainer = () => {
   const [pokeList, setPokeList] = useState([]);
   const [pokemon, setPokemon] = useState([])
+  const [error, setError] = useState('')
 
   useEffect(() => {
+    setError('');
     fetchPokemon()
     .then(data => {
       setPokeList([...data.results]);
+    })
+    .catch(error => {
+      setError(error);
     })
   }, []);
 
@@ -28,9 +34,12 @@ const PokemonContainer = () => {
   }, [pokeList]);
 
   return (
-    <section className='pokemon-container'>
-      {pokemon}
-    </section>
+    error ? <ErrorMessage /> :
+    (
+      <section className='pokemon-container'>
+        {pokemon}
+      </section>
+    )
   );
 }
 

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -9,23 +9,21 @@ import { frontSprites } from '../../assets/mock-sprites';
 const PokemonContainer = () => {
   const [pokeList, setPokeList] = useState([]);
   const [pokemonComponents, setPokemonComponents] = useState([])
-  const [nextUrl, setNextUrl] = useState('');
 
   useEffect(() => {
     fetchPokemon()
     .then(data => {
       setPokeList([...data.results]);
-      setNextUrl(data.next);
       return data.results;
     })
     .then(newPokemon => {
-      const newPokemonComponents = newPokemon.map((pokemon, i) => {
+      const selectedPokemonComponents = newPokemon.map((pokemon, i) => {
         return (
           <Pokemon dexNum={i + 1} name={pokemon.name} />
         )
       });
 
-      setPokemonComponents(newPokemonComponents)
+      setPokemonComponents(selectedPokemonComponents)
     });
   }, []);
 

--- a/src/utils/apiCalls.js
+++ b/src/utils/apiCalls.js
@@ -1,5 +1,5 @@
-const fetchPokemon = () => {
-  return fetch('https://pokeapi.co/api/v2/pokemon/')
+const fetchPokemon = (dexNum = '') => {
+  return fetch(`https://pokeapi.co/api/v2/pokemon/${dexNum}`)
     .then(response => {
       if (!response.ok) {
         throw new Error(`${response.status}: ${response.statusText}`)
@@ -9,4 +9,4 @@ const fetchPokemon = () => {
     });
 }
 
-export default fetchPokemon;
+export default fetchPokemon

--- a/src/utils/apiCalls.js
+++ b/src/utils/apiCalls.js
@@ -1,0 +1,12 @@
+const fetchPokemon = () => {
+  return fetch('https://pokeapi.co/api/v2/pokemon/')
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`${response.status}: ${response.statusText}`)
+      } else {
+        return response.json();
+      }
+    });
+}
+
+export default fetchPokemon;

--- a/src/utils/apiCalls.js
+++ b/src/utils/apiCalls.js
@@ -1,5 +1,8 @@
-const fetchPokemon = (dexNum = '') => {
-  return fetch(`https://pokeapi.co/api/v2/pokemon/${dexNum}`)
+const fetchPokemon = (selectedPokemon) => {
+  const allPokemon = 'https://pokeapi.co/api/v2/pokemon/?limit=2000';
+  let url = selectedPokemon ? selectedPokemon : allPokemon
+
+  return fetch(url)
     .then(response => {
       if (!response.ok) {
         throw new Error(`${response.status}: ${response.statusText}`)

--- a/src/utils/apiCalls.js
+++ b/src/utils/apiCalls.js
@@ -1,5 +1,5 @@
 const fetchPokemon = (selectedPokemon) => {
-  const allPokemon = 'https://pokeapi.co/api/v2/pokemon/?limit=2000';
+  const allPokemon = 'https://pokeapi.co/api/v2/pokemon/?limit=1008';
   let url = selectedPokemon ? selectedPokemon : allPokemon
 
   return fetch(url)


### PR DESCRIPTION
### Description
Renders all Pokemon when user visits home page at `/`

### Related Issue(s)
- closes #9 

### Changes

- Updates `fetchPokemon` to set the page limit to 1008 to fetch all Pokemon
- Changes PokemonContainer to have `pokeList`, `pokemon`, and `error` states
- `fetchPokemon` is invoked when component mounts and `pokeList` is updated with the fetched data
- `pokeList` is used to create `Pokemon` whenever its state is updated
- `PokemonContainer` conditionally renders `Error` or `Pokemon`

### Additional Notes
- The page limit meets MVP but should be made dynamic in future iterations. Originally, the limit was set to be 2000, and it was found that the last several results were not Pokemon and threw 404 errors. Will need to find solution and after MVP is met, #28 should be top priority.
