### PR TITLE
Testing/spriteview

### DIFF
--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -58,11 +58,8 @@ describe('Visit Sprite Page', () => {
       .children().should('have.length', 20);
   });
 
-  it('Should have the Pokemon\'s name and all its sprites', () => {
+  it('Should have all the Pokemon\'s sprites', () => {
     cy.visitBulbasaur();
-    
-    cy.get('h1')
-      .contains('BULBASAUR');
 
     cy.get('.sprites-container')
       .children().should('have.length', 72);
@@ -76,11 +73,8 @@ describe('Visit Sprite Page', () => {
       .should('have.attr', 'src', 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/icons/1.png');
     });
 
-  it('Should have the other Pokemon\'s name and all its sprites', () => {
+  it('Should have all the other Pokemon\'s sprites if it is clicked', () => {
     cy.visitCharmander();
-    
-    cy.get('h1')
-      .contains('CHARMANDER');
 
     cy.get('.sprites-container')
       .children().should('have.length', 72);
@@ -117,6 +111,8 @@ describe('Visit Bad Pokemon URL', () => {
   });
 
   it('Should show an error message if the user enters a bad URL end path', () => {
-    
+    cy.get('.error-message')
+    .contains('h1', 'Wild ERROR Appeared!')
+    .siblings('p', 'Try again or come back later.');
   });
 });

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -109,3 +109,14 @@ describe('Visit Sad Sprite Page', () => {
       .siblings('p', 'Try again or come back later.');
   });
 });
+
+describe('Visit Bad Pokemon URL', () => {
+  beforeEach('visit bad Pokemon URL', () => {
+    cy.visitHome();
+    cy.visit('http://localhost:3000/potato')
+  });
+
+  it('Should show an error message if the user enters a bad URL end path', () => {
+    
+  });
+});

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -5,7 +5,18 @@ describe('Visit Sprite Page', () => {
 
   it('Should visit a Pokemon\'s sprite page when it is clicked', () => {
     cy.get('.pokemon-container > div > :nth-child(1)').click()
-      .url().should('eq', 'http://localhost:3000/bulbasaur')
+    .url().should('eq', 'http://localhost:3000/bulbasaur')
+  });
+  
+  it('Should be able to navigate between the home page and sprite page with browser history', () => {
+    cy.get('.pokemon-container > div > :nth-child(1)').click()
+    .url().should('eq', 'http://localhost:3000/bulbasaur');
+    
+    cy.go('back')
+    .url().should('eq', 'http://localhost:3000/');
+    
+    cy.go('forward')
+    .url().should('eq', 'http://localhost:3000/bulbasaur');
   });
 
   it('Should have a header with a title, subtitle, pokeball logo, and Home button', () => {

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -4,12 +4,12 @@ describe('Visit Sprite Page', () => {
   });
 
   it('Should visit a Pokemon\'s sprite page when it is clicked', () => {
-    cy.get('.pokemon-container > div > :nth-child(1)').click()
+    cy.visitBulbasaur()
     .url().should('eq', 'http://localhost:3000/bulbasaur')
   });
   
   it('Should be able to navigate between the home page and sprite page with browser history', () => {
-    cy.get('.pokemon-container > div > :nth-child(1)').click()
+    cy.visitBulbasaur()
     .url().should('eq', 'http://localhost:3000/bulbasaur');
     
     cy.go('back')

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -1,0 +1,9 @@
+describe('Visit Sprite Page', () => {
+  beforeEach('Intercept and stub main page', () => {
+    cy.visitHome()
+  });
+
+  it('', () => {
+
+  });
+});

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -5,7 +5,12 @@ describe('Visit Sprite Page', () => {
 
   it('Should visit a Pokemon\'s sprite page when it is clicked', () => {
     cy.visitBulbasaur()
-    .url().should('eq', 'http://localhost:3000/bulbasaur')
+    .url().should('eq', 'http://localhost:3000/bulbasaur');
+  });
+  
+  it('Should visit another Pokemon\'s sprite page when it is clicked', () => {
+    cy.visitCharmander()
+    .url().should('eq', 'http://localhost:3000/charmander');
   });
   
   it('Should be able to navigate between the home page and sprite page with browser history', () => {
@@ -20,6 +25,8 @@ describe('Visit Sprite Page', () => {
   });
 
   it('Should have a header with a title, subtitle, pokeball logo, and Home button', () => {
+    cy.visitBulbasaur()
+
     cy.get('header')
       .find('.title-logo')
       .should('have.attr', 'src', '/static/media/title-logo.4eb791ae459a4d4e9f0f.png')
@@ -37,5 +44,17 @@ describe('Visit Sprite Page', () => {
       
     cy.get('header')
     .contains('button', 'HOME');
+  });
+
+  it('Should navigate to the home page when the Home button is clicked', () => {
+    cy.visitBulbasaur()
+      .get('.home-button').click()
+      .url().should('eq', 'http://localhost:3000/');
+    
+    cy.get('.pokemon-container')
+      .contains('h2', 'Click a Pokemon to view its pixel art!');
+
+    cy.get('.pokemon-container > div')
+      .children().should('have.length', 20);
   });
 });

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -57,4 +57,42 @@ describe('Visit Sprite Page', () => {
     cy.get('.pokemon-container > div')
       .children().should('have.length', 20);
   });
+
+  it('Should have the Pokemon\'s name and all its sprites', () => {
+    cy.visitBulbasaur();
+    
+    cy.get('h1')
+      .contains('BULBASAUR');
+
+    cy.get('.sprites-container')
+      .children().should('have.length', 72);
+
+    cy.get('.sprites-container')
+      .children().first()
+      .should('have.attr', 'src', 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/1.png');
+
+    cy.get('.sprites-container')
+      .children().last()
+      .should('have.attr', 'src', 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/icons/1.png');
+    });
+
+  it('Should have the other Pokemon\'s name and all its sprites', () => {
+    cy.visitCharmander();
+    
+    cy.get('h1')
+      .contains('CHARMANDER');
+
+    cy.get('.sprites-container')
+      .children().should('have.length', 72);
+
+    cy.get('.sprites-container')
+      .children().first()
+      .should('have.attr', 'src', 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/4.png')
+      .should('be.visible');
+      
+      cy.get('.sprites-container')
+      .children().last()
+      .should('have.attr', 'src', 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/icons/4.png')
+      .should('be.visible');
+    });
 });

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -3,7 +3,28 @@ describe('Visit Sprite Page', () => {
     cy.visitHome()
   });
 
-  it('', () => {
+  it('Should visit a Pokemon\'s sprite page when it is clicked', () => {
+    cy.get('.pokemon-container > div > :nth-child(1)').click()
+      .url().should('eq', 'http://localhost:3000/bulbasaur')
+  });
 
+  it('Should have a header with a title, subtitle, pokeball logo, and Home button', () => {
+    cy.get('header')
+      .find('.title-logo')
+      .should('have.attr', 'src', '/static/media/title-logo.4eb791ae459a4d4e9f0f.png')
+      .should('have.attr', 'alt', 'pixeldex title logo')
+      .should('be.visible');
+      
+      cy.get('header')
+      .contains('p', 'Unleash the pixels, catch the nostalgia!');
+      
+      cy.get('header')
+      .find('.pokeball-logo')
+      .should('have.attr', 'src', '/static/media/pokeball-logo.178c73ab034c28222c35.png')
+      .should('have.attr', 'alt', 'pixelated pokeball logo')
+      .should('be.visible');
+      
+    cy.get('header')
+    .contains('button', 'HOME');
   });
 });

--- a/cypress/e2e/view_sprites.cy.js
+++ b/cypress/e2e/view_sprites.cy.js
@@ -96,3 +96,16 @@ describe('Visit Sprite Page', () => {
       .should('be.visible');
     });
 });
+
+describe('Visit Sad Sprite Page', () => {
+  beforeEach('intercept bulbasaur and responsd with 404', () => {
+    cy.visitHome();
+    cy.visitSadBulbasaur();
+  });
+
+  it('Should tell the user if it failed to fetch the Pokemon\'s sprites', () => {
+    cy.get('.error-message')
+      .contains('h1', 'Wild ERROR Appeared!')
+      .siblings('p', 'Try again or come back later.');
+  });
+});

--- a/cypress/fixtures/bulbasaur_sample.json
+++ b/cypress/fixtures/bulbasaur_sample.json
@@ -1,0 +1,178 @@
+{
+  "sprites": {
+    "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/1.png",
+    "back_female": null,
+    "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/1.png",
+    "back_shiny_female": null,
+    "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
+    "front_female": null,
+    "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/1.png",
+    "front_shiny_female": null,
+    "other": {
+      "dream_world": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/1.svg",
+        "front_female": null
+      },
+      "home": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/1.png",
+        "front_female": null,
+        "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/shiny/1.png",
+        "front_shiny_female": null
+      },
+      "official-artwork": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/1.png",
+        "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/shiny/1.png"
+      }
+    },
+    "versions": {
+      "generation-i": {
+        "red-blue": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/back/1.png",
+          "back_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/back/gray/1.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/transparent/back/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/1.png",
+          "front_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/gray/1.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/transparent/1.png"
+        },
+        "yellow": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/back/1.png",
+          "back_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/back/gray/1.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/transparent/back/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/1.png",
+          "front_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/gray/1.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/transparent/1.png"
+        }
+      },
+      "generation-ii": {
+        "crystal": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/back/1.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/back/shiny/1.png",
+          "back_shiny_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/back/shiny/1.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/back/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/shiny/1.png",
+          "front_shiny_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/shiny/1.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/1.png"
+        },
+        "gold": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/back/1.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/back/shiny/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/shiny/1.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/transparent/1.png"
+        },
+        "silver": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/back/1.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/back/shiny/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/shiny/1.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/transparent/1.png"
+        }
+      },
+      "generation-iii": {
+        "emerald": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/emerald/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/emerald/shiny/1.png"
+        },
+        "firered-leafgreen": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/back/1.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/back/shiny/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/shiny/1.png"
+        },
+        "ruby-sapphire": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/back/1.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/back/shiny/1.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/1.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/shiny/1.png"
+        }
+      },
+      "generation-iv": {
+        "diamond-pearl": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/back/1.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/back/shiny/1.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/shiny/1.png",
+          "front_shiny_female": null
+        },
+        "heartgold-soulsilver": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/back/1.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/back/shiny/1.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/shiny/1.png",
+          "front_shiny_female": null
+        },
+        "platinum": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/back/1.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/back/shiny/1.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/shiny/1.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-v": {
+        "black-white": {
+          "animated": {
+            "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/back/1.gif",
+            "back_female": null,
+            "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/back/shiny/1.gif",
+            "back_shiny_female": null,
+            "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/1.gif",
+            "front_female": null,
+            "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/shiny/1.gif",
+            "front_shiny_female": null
+          },
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/back/1.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/back/shiny/1.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/shiny/1.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-vi": {
+        "omegaruby-alphasapphire": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/omegaruby-alphasapphire/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/omegaruby-alphasapphire/shiny/1.png",
+          "front_shiny_female": null
+        },
+        "x-y": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/x-y/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/x-y/shiny/1.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-vii": {
+        "icons": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/icons/1.png",
+          "front_female": null
+        },
+        "ultra-sun-ultra-moon": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/ultra-sun-ultra-moon/1.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/ultra-sun-ultra-moon/shiny/1.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-viii": {
+        "icons": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/icons/1.png",
+          "front_female": null
+        }
+      }
+    }
+  }
+}

--- a/cypress/fixtures/charmander_sample.json
+++ b/cypress/fixtures/charmander_sample.json
@@ -1,0 +1,178 @@
+{
+  "sprites": {
+    "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/4.png",
+    "back_female": null,
+    "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/4.png",
+    "back_shiny_female": null,
+    "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png",
+    "front_female": null,
+    "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/4.png",
+    "front_shiny_female": null,
+    "other": {
+      "dream_world": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/4.svg",
+        "front_female": null
+      },
+      "home": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/4.png",
+        "front_female": null,
+        "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/shiny/4.png",
+        "front_shiny_female": null
+      },
+      "official-artwork": {
+        "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/4.png",
+        "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/shiny/4.png"
+      }
+    },
+    "versions": {
+      "generation-i": {
+        "red-blue": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/back/4.png",
+          "back_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/back/gray/4.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/transparent/back/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/4.png",
+          "front_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/gray/4.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/transparent/4.png"
+        },
+        "yellow": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/back/4.png",
+          "back_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/back/gray/4.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/transparent/back/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/4.png",
+          "front_gray": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/gray/4.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/transparent/4.png"
+        }
+      },
+      "generation-ii": {
+        "crystal": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/back/4.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/back/shiny/4.png",
+          "back_shiny_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/back/shiny/4.png",
+          "back_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/back/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/shiny/4.png",
+          "front_shiny_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/shiny/4.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/crystal/transparent/4.png"
+        },
+        "gold": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/back/4.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/back/shiny/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/shiny/4.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/gold/transparent/4.png"
+        },
+        "silver": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/back/4.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/back/shiny/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/shiny/4.png",
+          "front_transparent": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-ii/silver/transparent/4.png"
+        }
+      },
+      "generation-iii": {
+        "emerald": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/emerald/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/emerald/shiny/4.png"
+        },
+        "firered-leafgreen": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/back/4.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/back/shiny/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/firered-leafgreen/shiny/4.png"
+        },
+        "ruby-sapphire": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/back/4.png",
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/back/shiny/4.png",
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/4.png",
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/ruby-sapphire/shiny/4.png"
+        }
+      },
+      "generation-iv": {
+        "diamond-pearl": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/back/4.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/back/shiny/4.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/diamond-pearl/shiny/4.png",
+          "front_shiny_female": null
+        },
+        "heartgold-soulsilver": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/back/4.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/back/shiny/4.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/heartgold-soulsilver/shiny/4.png",
+          "front_shiny_female": null
+        },
+        "platinum": {
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/back/4.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/back/shiny/4.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iv/platinum/shiny/4.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-v": {
+        "black-white": {
+          "animated": {
+            "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/back/4.gif",
+            "back_female": null,
+            "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/back/shiny/4.gif",
+            "back_shiny_female": null,
+            "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/4.gif",
+            "front_female": null,
+            "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/shiny/4.gif",
+            "front_shiny_female": null
+          },
+          "back_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/back/4.png",
+          "back_female": null,
+          "back_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/back/shiny/4.png",
+          "back_shiny_female": null,
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/shiny/4.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-vi": {
+        "omegaruby-alphasapphire": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/omegaruby-alphasapphire/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/omegaruby-alphasapphire/shiny/4.png",
+          "front_shiny_female": null
+        },
+        "x-y": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/x-y/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vi/x-y/shiny/4.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-vii": {
+        "icons": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/icons/4.png",
+          "front_female": null
+        },
+        "ultra-sun-ultra-moon": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/ultra-sun-ultra-moon/4.png",
+          "front_female": null,
+          "front_shiny": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-vii/ultra-sun-ultra-moon/shiny/4.png",
+          "front_shiny_female": null
+        }
+      },
+      "generation-viii": {
+        "icons": {
+          "front_default": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-viii/icons/4.png",
+          "front_female": null
+        }
+      }
+    }
+  }
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,9 +13,15 @@ Cypress.Commands.add('visitSadHome', () => {
 });
 
 Cypress.Commands.add('visitBulbasaur', () => {
+  cy.intercept('https://pokeapi.co/api/v2/pokemon/bulbasaur', {
+    fixture: 'bulbasaur_sample'
+  })
   cy.get('.pokemon-container > div > :nth-child(1)').click();
 });
 
 Cypress.Commands.add('visitCharmander', () => {
-  cy.get('.pokemon-container > div > :nth-child(4)').click();
+  cy.intercept('https://pokeapi.co/api/v2/pokemon/bulbasaur', {
+    fixture: 'charmander_sample'
+  })
+  .get('.pokemon-container > div > :nth-child(4)').click();
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('visitBulbasaur', () => {
 });
 
 Cypress.Commands.add('visitCharmander', () => {
-  cy.intercept('https://pokeapi.co/api/v2/pokemon/bulbasaur', {
+  cy.intercept('https://pokeapi.co/api/v2/pokemon/charmander', {
     fixture: 'charmander_sample'
   })
   .get('.pokemon-container > div > :nth-child(4)').click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,3 +11,11 @@ Cypress.Commands.add('visitSadHome', () => {
   })
   .visit('http://localhost:3000/')
 });
+
+Cypress.Commands.add('visitBulbasaur', () => {
+  cy.get('.pokemon-container > div > :nth-child(1)').click();
+});
+
+Cypress.Commands.add('visitCharmander', () => {
+  cy.get('.pokemon-container > div > :nth-child(4)').click();
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,11 +1,11 @@
-Cypress.Commands.add('loadPage', () => {
+Cypress.Commands.add('visitHome', () => {
   cy.intercept('https://pokeapi.co/api/v2/pokemon/?limit=1008', {
     fixture: 'all_pokemon_sample',
   })
   .visit('http://localhost:3000/')
 });
 
-Cypress.Commands.add('loadSadPage', () => {
+Cypress.Commands.add('visitSadHome', () => {
   cy.intercept('https://pokeapi.co/api/v2/pokemon/?limit=1008', {
     status: 404,
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,3 +25,10 @@ Cypress.Commands.add('visitCharmander', () => {
   })
   .get('.pokemon-container > div > :nth-child(4)').click();
 });
+
+Cypress.Commands.add('visitSadBulbasaur', () => {
+  cy.intercept('https://pokeapi.co/api/v2/pokemon/?limit=1008', {
+    status: 404,
+  })
+  .visit('http://localhost:3000/')
+});

--- a/src/components/SpriteView/SpriteView.js
+++ b/src/components/SpriteView/SpriteView.js
@@ -8,7 +8,6 @@ const SpriteView = () => {
 
   return (
     <main>
-      <h1>{pokemonName.toUpperCase()}</h1>
       <SpritesContainer pokemonName={pokemonName} />
     </main>
   );


### PR DESCRIPTION
### Description
Tested all paths for when the user visits the sprite page, including sad paths.

### Related Issue(s)
- closes #13 

### Changes

- Adds `view_sprites.cy.js`
- Adds new fixtures and intercepts for Bulbasaur and Charmander
- Removed Pokemon name header from Sprite View (see notes below)

### Additional Notes

- Found that when the user enters a bad URL end path (i.e. one that does match a Pokemon), `ErrorMessage` correctly appears, but `SpriteView` still renders. The only element from `SpriteView` present is the `h1`, displaying the end path that the user entered. Due to the deadline coming up, I decided to remove the header and make a ticket for a future feature. Will make it a top priority after meeting MVP and deployment.
