### PR TITLE
Refactor/components

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom'
 import './Header.css';
 import pokeballLogo from '../../assets/pokeball-logo.png'
 import titleLogo from '../../assets/title-logo.png'
-import { Link } from 'react-router-dom'
 
 const Header = () => {
   return (

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
 import './Header.css';
-import pokeballLogo from '../../assets/pokeball-logo.png'
-import titleLogo from '../../assets/title-logo.png'
+import pokeballLogo from '../../assets/pokeball-logo.png';
+import titleLogo from '../../assets/title-logo.png';
 
 const Header = () => {
   return (
@@ -21,6 +21,6 @@ const Header = () => {
       </Link>
     </header>
   );
-};
+}
 
 export default Header;

--- a/src/components/HomeView/HomeView.js
+++ b/src/components/HomeView/HomeView.js
@@ -4,10 +4,10 @@ import PokemonContainer from '../PokemonContainer/PokemonContainer';
 import SearchBar from '../SearchBar/SearchBar';
 
 const HomeView = () => {
-  const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useState('');
 
   const addSearchTerm = term => {
-    setSearchTerm(term)
+    setSearchTerm(term);
   }
 
   return (

--- a/src/components/HomeView/HomeView.js
+++ b/src/components/HomeView/HomeView.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import './HomeView.css';
-import SearchBar from '../SearchBar/SearchBar';
 import PokemonContainer from '../PokemonContainer/PokemonContainer';
+import SearchBar from '../SearchBar/SearchBar';
 
 const HomeView = () => {
   const [searchTerm, setSearchTerm] = useState('')

--- a/src/components/Pokemon/Pokemon.js
+++ b/src/components/Pokemon/Pokemon.js
@@ -4,19 +4,19 @@ import PropTypes from 'prop-types';
 import './Pokemon.css';
 
 const Pokemon = ({ dexNum, name }) => {
-  const spriteSrc = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${dexNum}.png`
+  const spriteSrc = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${dexNum}.png`;
 
   const formatDexNum = (num) => {
     const strNum = num.toString();
   
     if (strNum.length === 1) {
-      return `#000${strNum}`
+      return `#000${strNum}`;
     } else if (strNum.length === 2) {
-      return `#00${strNum}`
+      return `#00${strNum}`;
     } else if (strNum.length === 3) {
-      return `#0${strNum}`
+      return `#0${strNum}`;
     } else {
-      return `#${strNum}`
+      return `#${strNum}`;
     }
   }
 

--- a/src/components/Pokemon/Pokemon.js
+++ b/src/components/Pokemon/Pokemon.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import './Pokemon.css';
 
 const Pokemon = ({ dexNum, name }) => {

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import './PokemonContainer.css';
-import fetchPokemon from '../../utils/apiCalls';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
 import Pokemon from '../Pokemon/Pokemon';
+import fetchPokemon from '../../utils/apiCalls';
 
 const PokemonContainer = ({ searchTerm }) => {
   const [pokeList, setPokeList] = useState([]);

--- a/src/components/PokemonContainer/PokemonContainer.js
+++ b/src/components/PokemonContainer/PokemonContainer.js
@@ -7,9 +7,9 @@ import fetchPokemon from '../../utils/apiCalls';
 
 const PokemonContainer = ({ searchTerm }) => {
   const [pokeList, setPokeList] = useState([]);
-  const [pokemon, setPokemon] = useState([])
-  const [noMatchMessage, setNoMatchMessage] = useState('')
-  const [error, setError] = useState('')
+  const [pokemon, setPokemon] = useState([]);
+  const [noMatchMessage, setNoMatchMessage] = useState('');
+  const [error, setError] = useState('');
 
   useEffect(() => {
     setError('');
@@ -19,14 +19,14 @@ const PokemonContainer = ({ searchTerm }) => {
     })
     .catch(error => {
       setError(error);
-    })
+    });
   }, []);
 
   useEffect(() => {
     const pokemon = pokeList.length > 0 && pokeList.map((pokemon, i) => {
       return (
         <Pokemon key={i} dexNum={i + 1} name={pokemon.name} />
-      )
+      );
     });
 
     setPokemon(pokemon);
@@ -36,7 +36,7 @@ const PokemonContainer = ({ searchTerm }) => {
     let foundPokemon;
     let pokemonIndex;
 
-    setNoMatchMessage('')
+    setNoMatchMessage('');
     if (searchTerm !== '') {
       [foundPokemon, pokemonIndex] = pokeList.reduce((acc, pokemon, i) => {
         if (pokemon.name === searchTerm.toLowerCase()) {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -4,7 +4,7 @@ import './SearchBar.css';
 
 const SearchBar = ({ addSearchTerm }) => {
   const [pokemonName, setPokemonName] = useState('');
-  const [requiredMessage, setRequiredMessage] = useState('')
+  const [requiredMessage, setRequiredMessage] = useState('');
 
   const handleClick = event => {
     event.preventDefault();

--- a/src/components/SpritesContainer/SpritesContainer.css
+++ b/src/components/SpritesContainer/SpritesContainer.css
@@ -4,7 +4,7 @@
   margin-top: 5%;
   padding: 5%;
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
   border-radius: 10px;
   background-color: #F2F2F2;
@@ -16,10 +16,4 @@ h1 {
   padding: 2px 10% 0;
   border-bottom: 3px solid #dbdbdb;
   font-size: 24px;
-}
-
-.sprites-center {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
 }

--- a/src/components/SpritesContainer/SpritesContainer.js
+++ b/src/components/SpritesContainer/SpritesContainer.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import './SpritesContainer.css';
-import fetchPokemon from '../../utils/apiCalls';
-import Sprite from '../Sprite/Sprite';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
+import Sprite from '../Sprite/Sprite';
+import fetchPokemon from '../../utils/apiCalls';
 
 const SpritesContainer = ({ pokemonName }) => {
   const [pokemon, setPokemon] = useState({});

--- a/src/components/SpritesContainer/SpritesContainer.js
+++ b/src/components/SpritesContainer/SpritesContainer.js
@@ -49,10 +49,7 @@ const SpritesContainer = ({ pokemonName }) => {
     errorMessage ? <ErrorMessage /> :
     (
       <section className='sprites-container'>
-        <h1>{pokemonName.toUpperCase()}</h1>
-        <div className='sprites-center'>
-          {sprites}
-        </div>
+        {sprites}
       </section>
     )
   );

--- a/src/components/SpritesContainer/SpritesContainer.js
+++ b/src/components/SpritesContainer/SpritesContainer.js
@@ -11,7 +11,7 @@ const SpritesContainer = ({ pokemonName }) => {
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    const url = `https://pokeapi.co/api/v2/pokemon/${pokemonName}`
+    const url = `https://pokeapi.co/api/v2/pokemon/${pokemonName}`;
     fetchPokemon(url)
     .then(data => {
       setPokemon(data.sprites);

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,4 @@ root.render(
   </BrowserRouter>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/src/utils/apiCalls.js
+++ b/src/utils/apiCalls.js
@@ -1,15 +1,15 @@
 const fetchPokemon = (selectedPokemon) => {
   const allPokemon = 'https://pokeapi.co/api/v2/pokemon/?limit=1008';
-  let url = selectedPokemon ? selectedPokemon : allPokemon
+  let url = selectedPokemon ? selectedPokemon : allPokemon;
 
   return fetch(url)
     .then(response => {
       if (!response.ok) {
-        throw new Error(`${response.status}: ${response.statusText}`)
+        throw new Error(`${response.status}: ${response.statusText}`);
       } else {
         return response.json();
       }
     });
 }
 
-export default fetchPokemon
+export default fetchPokemon;


### PR DESCRIPTION
### Description
Component files and utils files have been edited to fit Turing style guidelines. Pokemon name was removed from SpriteContainer (see Additional Notes below)

### Related Issue(s)
- Related to #14 

### Changes

- Component file imports have consistent arrangement
- Semicolons/indentation/quotes were doublechecked
- Removed Pokemon name from SpriteContainer (see Additional Notes below)

### Additional Notes

- The Pokemon name was, once again, removed from the Sprite View. This was due to the time constraints and the necessity to deploy the site with MVP by tonight. The error occurring was the Pokemon's name was still appearing with a bad URL endpath. It would eventually go away and be replaced by the Error component. A more glaring error is the URL endpath can match a Pokemon's pokedex number and the API will still fetch that Pokemon's sprites. This resulted in a page that showed the Pokemon sprites, but the name would be displayed as the Pokedex number. To fit MVP, the name was elected to be left out of the Sprite View and be implemented in future iterations.
